### PR TITLE
Add a link to perlres

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Not Perl6 modules ;-P
 We also recommend these lists.
 
 * [Task::Kensho](https://github.com/EnlightenedPerlOrganisation/task-kensho "Task::Kensho")
-* [Perlres](https://github.com/thibaultduponchelle/perlres)
+* [Perlres - A list of resources about Perl](https://github.com/thibaultduponchelle/perlres)
 * [PerlMaven.com list of Perl Software](http://perlmaven.com/perl-based-open-source-products)
 * [Slaven's CPAN in a nutshell](https://github.com/eserte/srezic-misc/blob/master/cpan_in_a_nutshell/cpan_in_a_nutshell.pod)
 * Many Task::** Modules. (ex. Task::Plack, Task::BeLike::<AuthorName>...)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Not Perl6 modules ;-P
 We also recommend these lists.
 
 * [Task::Kensho](https://github.com/EnlightenedPerlOrganisation/task-kensho "Task::Kensho")
+* [Perlres](https://github.com/thibaultduponchelle/perlres)
 * [PerlMaven.com list of Perl Software](http://perlmaven.com/perl-based-open-source-products)
 * [Slaven's CPAN in a nutshell](https://github.com/eserte/srezic-misc/blob/master/cpan_in_a_nutshell/cpan_in_a_nutshell.pod)
 * Many Task::** Modules. (ex. Task::Plack, Task::BeLike::<AuthorName>...)


### PR DESCRIPTION
May I suggest to add a link to perlres (which is a king of awesome-perl not modules centric).

Thank you a lot.

Thibault