### PR TITLE
s/Params::Validate/Params::ValidationCompiler/

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We also recommend these lists.
 
 * [Data::Validator](https://metacpan.org/pod/Data::Validator) - Rule based validator on type constraint system.
 * [Params::Util](https://metacpan.org/pod/Params::Util) - Simple, compact and correct param-checking functions.
-* [Params::Validate](https://metacpan.org/pod/Params::Validate) - Validate method/function parameters.
+* [Params::ValidationCompiler](https://metacpan.org/pod/Params::ValidationCompiler) - Validate method/function parameters.
 * [Smart::Args](https://metacpan.org/pod/Smart::Args)
 
 ## Audio


### PR DESCRIPTION
See https://metacpan.org/pod/Params::Validate#DESCRIPTION

"I would recommend you consider using Params::ValidationCompiler instead.
That module, despite being pure Perl, is significantly faster than this
one, at the cost of having to adopt a type system such as Specio,
Type::Tiny, or the one shipped with Moose."