### PR TITLE
Remove Perl6 mention and Perl5 version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Awesome Perl [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-A curated list of awesome Perl5 resources, including frameworks, libraries and software. Inspired by [awesome-go](https://github.com/avelino/awesome-go).
-
-Not Perl6 modules ;-P
+A curated list of awesome Perl resources, including frameworks, libraries and software. Inspired by [awesome-go](https://github.com/avelino/awesome-go).
 
 ### Another module list
 


### PR DESCRIPTION
I propose to remove this from the very top of the document, as it may be confusing to uninitiated.

Perl 6 has been renamed to Raku quite a while ago and many sources which mentioned it have updated. There's no longer any ambiguity when it comes to major version numbering, Perl is just Perl now. Explicit version numbers will only cause more confusion and could make someone think this list is not for the newest version of Perl.