### PR TITLE
fixed CBOR::Free link in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ We also recommend these lists.
 *Libraries for serializing, formatting and parsing*
 
 * [BSON](https://metacpan.org/pod/BSON) - Binary JSON format
-* [CBOR::Free](https://metacpan.org/pod/CBOR::Free) - Support for (CBOR)[https://tools.ietf.org/html/rfc7049], IETF’s “binary JSON”
+* [CBOR::Free](https://metacpan.org/pod/CBOR::Free) - Support for [CBOR](https://tools.ietf.org/html/rfc7049), IETF’s “binary JSON”
 * [Data::Dumper::Simple](https://metacpan.org/pod/Data::Dumper::Simple) - Reduce and faster Data::Dumper and eval() equivalent
 * [Data::MessagePack](https://metacpan.org/pod/Data::MessagePack)
 * [JSON::PP](https://metacpan.org/pod/JSON::PP)


### PR DESCRIPTION
Markdown was wrong: () where [] should be, and vice versa